### PR TITLE
Cordova iOS 8 breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-ios-localized-strings",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "Enrico Deleo <hello@enricodeleo.com> (http://enricodeleo.com/)",
   "description": "Cordova / PhoneGap Plugin that exposes supported languages to the App Store (iTunes).",
   "cordova": {

--- a/scripts/add_supported_languages.js
+++ b/scripts/add_supported_languages.js
@@ -15,7 +15,7 @@ module.exports = context => {
 
   return new Promise((resolve, reject) => {
     let mainConfig = new ConfigParser(path.resolve(context.opts.projectRoot, 'config.xml'));
-    let name = mainConfig.name();
+    let name = 'App';
     let config = new ConfigParser(path.resolve(context.opts.projectRoot, 'platforms', 'ios', name, 'config.xml'));
     let MAIN_LANGUAGE = config.getGlobalPreference('MAIN_LANGUAGE');
     let ADDITIONAL_LANGUAGES = config.getGlobalPreference('ADDITIONAL_LANGUAGES');


### PR DESCRIPTION
Recent versions of cordova-ios (8.x) have standardized the internal iOS folder and target structure to /platforms/ios/App/. 
This change fixes the hook to correctly locate the Info.plist and Config.xml project files.